### PR TITLE
Close file handle

### DIFF
--- a/statik.go
+++ b/statik.go
@@ -52,6 +52,7 @@ func main() {
 	if err != nil {
 		exitWithError(err)
 	}
+	file.Close()
 
 	err = os.Rename(file.Name(), path.Join(destDir, nameSourceFile))
 	if err != nil {


### PR DESCRIPTION
On windows, statik fail to rename directory because the temporary file doesn't closed before renaming.
