### PR TITLE
Convert OS-specific path separators to slash

### DIFF
--- a/statik.go
+++ b/statik.go
@@ -102,7 +102,7 @@ func generateSource(srcPath string) (file *os.File, err error) {
 		if err != nil {
 			return err
 		}
-		fHeader.Name = relPath
+		fHeader.Name = filepath.ToSlash(relPath)
 		f, err := w.CreateHeader(fHeader)
 		if err != nil {
 			return err


### PR DESCRIPTION
.. otherwise subdirectories are not accessible when using `statik` on Windows.