### PR TITLE
fixed 'invalid cross-device link' problem

### DIFF
--- a/statik.go
+++ b/statik.go
@@ -61,32 +61,34 @@ func main() {
 
 func copy(src, dest string) error {
 	// Try to rename generated source ...
-	if err := os.Rename(src, dest); err != nil {
-		// ... if that failed (might do so due to temporary file residing on a
-		// different device) try to copy byte by byte.
-
-		rc, err := os.Open(src)
-		if err != nil {
-			return err
-		}
-		defer rc.Close()
-
-		if _, err = os.Stat(dest); !os.IsNotExist(err) {
-			return fmt.Errorf("file %q already exists", dest)
-		}
-
-		wc, err := os.Create(dest)
-		if err != nil {
-			return err
-		}
-		defer wc.Close()
-
-		if _, err = io.Copy(wc, rc); err != nil {
-			_ = os.Remove(dest)
-			return err
-		}
+	if err := os.Rename(src, dest); err == nil {
+		return nil
 	}
-	return nil
+
+	// ... if the rename failed (might do so due to temporary file residing on a
+	// different device) try to copy byte by byte.
+
+	rc, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	if _, err = os.Stat(dest); !os.IsNotExist(err) {
+		return fmt.Errorf("file %q already exists", dest)
+	}
+
+	wc, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer wc.Close()
+
+	if _, err = io.Copy(wc, rc); err != nil {
+		// Delete remains of failed copy attempt.
+		_ = os.Remove(dest)
+	}
+	return err
 }
 
 // Walks on the source path and generates source code


### PR DESCRIPTION
Renaming the generated source file failed for me with the following message:
rename /tmp/statik888425530 statik/statik.go: invalid cross-device link

Try to rename and if that fails copy byte by byte.