### PR TITLE
replace rename by copy and delete

### DIFF
--- a/statik.go
+++ b/statik.go
@@ -53,10 +53,29 @@ func main() {
 		exitWithError(err)
 	}
 
-	err = os.Rename(file.Name(), path.Join(destDir, nameSourceFile))
+	err = copy(file.Name(), path.Join(destDir, nameSourceFile))
 	if err != nil {
 		exitWithError(err)
 	}
+	err = os.Remove(file.Name())
+	if err != nil {
+		exitWithError(err)
+	}
+}
+
+// copy the content of a file to a new location
+func copy(src string, dst string) error {
+	// Read all content of src to data
+	data, err := ioutil.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	// Write data to dst
+	err = ioutil.WriteFile(dst, data, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Walks on the source path and generates source code


### PR DESCRIPTION
On linux system rename cannot rename files accross devices, so we replace this bu simply copy and delete.

Some information about this here: https://groups.google.com/forum/#!topic/golang-dev/5w7Jmg_iCJQ

Please review this carefully I'm still new with Go