### PR TITLE
Fix master for Go < 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 
 go:
+  - 1.9.x
   - 1.10.3
 
 install:

--- a/statik.go
+++ b/statik.go
@@ -160,7 +160,8 @@ func generateSource(srcPath string) (file *os.File, err error) {
 		if *flagNoMtime {
 			// Always use the same modification time so that
 			// the output is deterministic with respect to the file contents.
-			fHeader.Modified = mtimeDate
+			// Do NOT use fHeader.Modified as it only works on go >= 1.10
+			fHeader.SetModTime(mtimeDate)
 		}
 		fHeader.Name = filepath.ToSlash(relPath)
 		if !*flagNoCompress {


### PR DESCRIPTION
A recent patch (#46) broke go get using versions of Go older than 1.10 as it is
using the newly introduced FileHeader.Modified

This patch replaces the .Modified by a call to the deprecated SetModTime to maintain compatibility.

Fix #50