### PR TITLE
Fix Readdir() and Name()

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -70,9 +70,14 @@ func New() (http.FileSystem, error) {
 		files["/"+zipFile.Name] = f
 	}
 	for fn := range files {
+		// Recursively go down the folders until get to the /
 		dn := path.Dir(fn)
-		if _, ok := files[dn]; !ok {
-			files[dn] = file{FileInfo: dirInfo{path.Base(dn)}, fs: fs}
+		for dn != fn {
+			if _, ok := files[dn]; !ok {
+				files[dn] = file{FileInfo: dirInfo{path.Base(dn)}, fs: fs}
+			}
+			fn = dn
+			dn = path.Dir(fn)
 		}
 	}
 	return fs, nil


### PR DESCRIPTION
Statik's `Readdir` did not behave in the same way as a `http.FileSystem`'s Readdir. Similarly, the `Name` function in `http.FileSystem` returned the base name, and not a full file path.

This commit fixes both issues, making both `Name` and `Readdir` behave in the same way as when running the raw filesystem directly using `http.Dir()`

The commit is an extension of #55, which was a first step towards replicating the correct behaviour, but failed to account for the `Name()` issue, and did not include the necessary extra `Trim` to get rid of leading slash.

The corresponding tests ensure that the results are identical for `http.Dir()` and statik.

Closes #58 