### PR TITLE
Travis-CI: set checkout dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ go:
   - 1.9.x
   - 1.10.3
 
+go_import_path: github.com/rakyll/statik
+
 install:
   - go build -v
   - ./statik -f -src=./example/public -dest=./example/


### PR DESCRIPTION
In Travis-CI.org configuration, set checkout dir to allow contributors to have Travis-CI to run on their forks using the code from their own fork.