### PR TITLE
fix force option behavior

### DIFF
--- a/statik.go
+++ b/statik.go
@@ -76,6 +76,10 @@ func main() {
 // rename tries to os.Rename, but fall backs to copying from src
 // to dest and unlink the source if os.Rename fails.
 func rename(src, dest string) error {
+	if _, err := os.Stat(dest); !os.IsNotExist(err) && !*flagForce {
+		return fmt.Errorf("file %q already exists; use -f to overwrite", dest)
+	}
+
 	// Try to rename generated source.
 	if err := os.Rename(src, dest); err == nil {
 		return nil
@@ -90,16 +94,6 @@ func rename(src, dest string) error {
 		rc.Close()
 		os.Remove(src) // ignore the error, source is in tmp.
 	}()
-
-	if _, err = os.Stat(dest); !os.IsNotExist(err) {
-		if *flagForce {
-			if err = os.Remove(dest); err != nil {
-				return fmt.Errorf("file %q could not be deleted", dest)
-			}
-		} else {
-			return fmt.Errorf("file %q already exists; use -f to overwrite", dest)
-		}
-	}
 
 	wc, err := os.Create(dest)
 	if err != nil {


### PR DESCRIPTION
Currently, the force flag is effective only when os.Rename fails. That is, if os.Rename succeeds, statik will overwrite the file regardless of the force flag.

Is this the intended behavior? As I feel it is not intuitive, I fix it.