### PR TITLE
fs: handle Readdir(0) same as Readdir(< 0)

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -182,7 +182,7 @@ func (f *httpFile) Readdir(count int) ([]os.FileInfo, error) {
 	}
 
 	// If count is positive, the specified number of files will be returned,
-	// and if negative, all remaining files will be returned.
+	// and if non-positive, all remaining files will be returned.
 	// The reading position of which file is returned is held in dirIndex.
 	fnames := f.file.fs.dirs[di.name]
 	flen := len(fnames)
@@ -196,7 +196,7 @@ func (f *httpFile) Readdir(count int) ([]os.FileInfo, error) {
 		return fis, io.EOF
 	}
 	var end int
-	if count < 0 {
+	if count <= 0 {
 		end = flen
 	} else {
 		end = start + count

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -262,6 +262,21 @@ func TestHTTPFile_Readdir(t *testing.T) {
 			t.Errorf("got: %d, expect: 3", len(fis))
 		}
 	})
+	t.Run("Readdir(0)", func(t *testing.T) {
+		dir, err := fs.Open("/")
+		if err != nil {
+			t.Errorf("fs.Open(/) = %v", err)
+			return
+		}
+		fis, err := dir.Readdir(0)
+		if err != nil {
+			t.Errorf("dir.Readdir(0) = %v", err)
+			return
+		}
+		if len(fis) != 3 {
+			t.Errorf("got: %d, expect: 3", len(fis))
+		}
+	})
 	t.Run("Readdir(>0)", func(t *testing.T) {
 		dir, err := fs.Open("/")
 		if err != nil {
@@ -412,7 +427,7 @@ func mustZipTree(srcPath string) string {
 	if err := w.Close(); err != nil {
 		panic(err)
 	}
-	return string(out.Bytes())
+	return out.String()
 }
 
 // mustReadFile returns the file contents. Panics on any errors.


### PR DESCRIPTION
Implementations of the `File.Readdir` method are expected to treat
all n <= 0 values the same, returning all the `os.FileInfo` structures
from the directory in a single slice. This is documented at
https://godoc.org/net/http#File.Readdir and https://godoc.org/os#File.Readdir.

Previously, the n == 0 value was not being handled correctly.
This change fixes it by making it work the same as all other
negative values of n.

Add a test case for it.

Also simplify `string(out.Bytes())` to just `out.String()` in a test.

Fixes #68.
Fixes shurcooL/httpfs#8.
Closes shurcooL/httpfs#9.