### PR TITLE
move dependency on net/http in fs to httpfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ In your program, all your need to do is to import the generated package, initial
 ~~~ go
 import (
   "github.com/rakyll/statik/fs"
+  "github.com/rakyll/statik/fs/httpfs"
 
   _ "./statik" // TODO: Replace with the absolute import path
 )
@@ -34,7 +35,7 @@ import (
     log.Fatal(err)
   }
 
-  http.Handle("/public/", http.StripPrefix("/public/", http.FileServer(statikFS)))
+  http.Handle("/public/", http.StripPrefix("/public/", http.FileServer(httpfs.System(statikFS))))
   http.ListenAndServe(":8080", nil)
 ~~~
 

--- a/example/main.go
+++ b/example/main.go
@@ -8,6 +8,7 @@ import (
 
 	_ "github.com/rakyll/statik/example/statik"
 	"github.com/rakyll/statik/fs"
+	"github.com/rakyll/statik/fs/httpfs"
 )
 
 // Before buildling, run go generate.
@@ -18,6 +19,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	http.Handle("/public/", http.StripPrefix("/public/", http.FileServer(statikFS)))
+	http.Handle("/public/", http.StripPrefix("/public/", http.FileServer(httpfs.System(statikFS))))
 	http.ListenAndServe(":8080", nil)
 }

--- a/fs/httpfs/fs.go
+++ b/fs/httpfs/fs.go
@@ -2,6 +2,7 @@ package httpfs
 
 import (
 	"net/http"
+
 	"github.com/rakyll/statik/fs"
 )
 

--- a/fs/httpfs/fs.go
+++ b/fs/httpfs/fs.go
@@ -1,0 +1,20 @@
+package httpfs
+
+import (
+	"net/http"
+	"github.com/rakyll/statik/fs"
+)
+
+type system struct {
+	*fs.StatikFS
+}
+
+func System(fs *fs.StatikFS) system {
+	return system{
+		fs,
+	}
+}
+
+func (fs system) Open(name string) (http.File, error) {
+	return fs.StatikFS.Open(name)
+}

--- a/fs/walk.go
+++ b/fs/walk.go
@@ -17,7 +17,6 @@ package fs
 import (
 	"bytes"
 	"io"
-	"net/http"
 	"path"
 	"path/filepath"
 )
@@ -27,7 +26,7 @@ import (
 // All errors that arise visiting files and directories are filtered by walkFn.
 //
 // As with filepath.Walk, if the walkFn returns filepath.SkipDir, then the directory is skipped.
-func Walk(hfs http.FileSystem, root string, walkFn filepath.WalkFunc) error {
+func Walk(hfs *StatikFS, root string, walkFn filepath.WalkFunc) error {
 	dh, err := hfs.Open(root)
 	if err != nil {
 		return err
@@ -67,7 +66,7 @@ func Walk(hfs http.FileSystem, root string, walkFn filepath.WalkFunc) error {
 
 // ReadFile reads the contents of the file of hfs specified by name.
 // Just as ioutil.ReadFile does.
-func ReadFile(hfs http.FileSystem, name string) ([]byte, error) {
+func ReadFile(hfs *StatikFS, name string) ([]byte, error) {
 	fh, err := hfs.Open(name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change wouldn't require people to depend on net/http

binary size:
without net/http: 2.4M
with net/http: 6.7M