### PR TITLE
Demonstrate reading files directly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ import (
   http.ListenAndServe(":8080", nil)
 ~~~
 
+You can also read the content of a single file:
+
 ~~~ go
 import (
   "github.com/rakyll/statik/fs"

--- a/README.md
+++ b/README.md
@@ -31,15 +31,44 @@ import (
   _ "./statik" // TODO: Replace with the absolute import path
 )
 
-// ...
+  // ...
 
   statikFS, err := fs.New()
   if err != nil {
     log.Fatal(err)
   }
-
+  
+  // Serve the contents over HTTP.
   http.Handle("/public/", http.StripPrefix("/public/", http.FileServer(statikFS)))
   http.ListenAndServe(":8080", nil)
+~~~
+
+~~~ go
+import (
+  "github.com/rakyll/statik/fs"
+
+  _ "./statik" // TODO: Replace with the absolute import path
+)
+
+  // ...
+
+  statikFS, err := fs.New()
+  if err != nil {
+    log.Fatal(err)
+  }
+  
+  // Access individual files by their paths.
+  r, err := statikFS.Open("/hello.txt")
+  if err != nil {
+    log.Fatal(err)
+  }    
+  defer r.Close()
+  contents, err := ioutil.ReadAll(r)
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  fmt.Println(string(contents))
 ~~~
 
 Visit http://localhost:8080/public/path/to/file to see your file.


### PR DESCRIPTION
When I first tried to use this project, I had a similar issue as https://github.com/rakyll/statik/issues/82

I wasn't able to find the files I'd added. I tried without it `hello.txt`, then I tried `/public/hello.txt`, then I tried a full package name, then I tried `/statik/hello.txt`, the full package name, and then went reading the code.

This pull request just updates the documentation and example to include an example of reading a single file.