### PR TITLE
Use os.PathSeparator to find files

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -71,7 +71,7 @@ func New() (http.FileSystem, error) {
 		if err != nil {
 			return nil, fmt.Errorf("statik/fs: error unzipping file %q: %s", zipFile.Name, err)
 		}
-		files["/"+zipFile.Name] = f
+		files[string(os.PathSeparator)+zipFile.Name] = f
 	}
 	for fn := range files {
 		// go up directories recursively in order to care deep directory


### PR DESCRIPTION
There was an issue on Windows where the path separator for !windows was hardcoded,
which did not play nice with the filepath.Clean() function.

It replaces all `/` with `\`.
The fix is to use the right path separator which makes it portable.

I don't think it impacts anything, since `/` in URLs will just be resolved
internaly to `\`.